### PR TITLE
fixed belongsTo relations

### DIFF
--- a/app/Comment.php
+++ b/app/Comment.php
@@ -24,7 +24,7 @@ class Comment extends Model
 
     public function action()
     {
-        return $this->hasOne(ActionType::class, 'id', 'action_type_id');
+        return $this->belongsTo(ActionType::class, 'action_type_id', 'id');
     }
 
     public function source()

--- a/app/Log.php
+++ b/app/Log.php
@@ -27,7 +27,7 @@ class Log extends Model
 
     public function action()
     {
-        return $this->hasOne('App\ActionType', 'id', 'action_type_id');
+        return $this->belongsTo(ActionType::class, 'action_type_id', 'id');
     }
 
     public function source()

--- a/app/Notice.php
+++ b/app/Notice.php
@@ -35,17 +35,17 @@ class Notice extends Model
 
     public function getActionAttribute()
     {
-        return $this->hasOne('App\ActionType', 'id', 'action_type_id')->first()->useAs('notice');
+        return $this->belongsTo(ActionType::class, 'action_type_id', 'id')->first()->useAs('notice');
     }
 
     public function getUserAttribute()
     {
-        return $this->hasOne('App\User', 'id', 'user_id')->first();
+        return $this->belongsTo(User::class, 'user_id', 'id')->first();
     }
 
     public function getSenderAttribute()
     {
-        return $this->hasOne('App\User', 'id', 'sender_id')->first();
+        return $this->belongsTo(User::class, 'sender_id', 'id')->first();
     }
 
     public function source()

--- a/app/OrderDetail.php
+++ b/app/OrderDetail.php
@@ -45,6 +45,6 @@ class OrderDetail extends Model
 
     public function getProductAttribute()
     {
-        return $this->hasOne(Product::class, 'id', 'product_id')->first();
+        return $this->belongsTo(Product::class, 'product_id', 'id')->first();
     }
 }


### PR DESCRIPTION
Hey Gustavo,
you have issues with `belongsTo` relations all over the place - using `hasOne` with inverted keys is going to work in some cases, will fail in others (try eg `has(relation)`). This PR fixes that.

Other than that a few friendly suggestions:
1. for all of these relations I left the keys to show what the correct order is, but they are reduntant - you can remove them.
2 review using *accessors* for those relations - you don't need that.
3. don't use `appends` extensively, as it leads to unexpected results.